### PR TITLE
iOS Bootcamp Challenge One - Stretch Goal

### DIFF
--- a/Week01/ColorPicker/ColorPicker/Base.lproj/Main.storyboard
+++ b/Week01/ColorPicker/ColorPicker/Base.lproj/Main.storyboard
@@ -16,7 +16,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="oeD-hr-3be">
-                                <rect key="frame" x="16" y="20" width="288" height="258"/>
+                                <rect key="frame" x="16" y="20" width="288" height="297"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Color Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hoz-n1-dFL">
                                         <rect key="frame" x="0.0" y="0.0" width="288" height="20.5"/>
@@ -24,14 +24,24 @@
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="dKN-m2-Maz">
+                                        <rect key="frame" x="0.0" y="28.5" width="288" height="32"/>
+                                        <segments>
+                                            <segment title="RGB"/>
+                                            <segment title="HSB"/>
+                                        </segments>
+                                        <connections>
+                                            <action selector="colorModelChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="dXa-8C-pQk"/>
+                                        </connections>
+                                    </segmentedControl>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Red" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dv7-RE-Ygz">
-                                        <rect key="frame" x="0.0" y="28.5" width="288" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="67.5" width="288" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="adJ-Dj-AkX">
-                                        <rect key="frame" x="0.0" y="57" width="288" height="30"/>
+                                        <rect key="frame" x="0.0" y="96" width="288" height="30"/>
                                         <subviews>
                                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="255" translatesAutoresizingMaskIntoConstraints="NO" id="3Ff-NT-s5N">
                                                 <rect key="frame" x="-2" y="0.0" width="253.5" height="31"/>
@@ -48,13 +58,13 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Green" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xKw-XP-vAx">
-                                        <rect key="frame" x="0.0" y="95" width="288" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="134" width="288" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Xo4-G5-EEf">
-                                        <rect key="frame" x="0.0" y="123.5" width="288" height="30"/>
+                                        <rect key="frame" x="0.0" y="162.5" width="288" height="30"/>
                                         <subviews>
                                             <slider opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="255" translatesAutoresizingMaskIntoConstraints="NO" id="efd-tO-tOb">
                                                 <rect key="frame" x="-2" y="0.0" width="253.5" height="31"/>
@@ -71,13 +81,13 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blue" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jSf-aT-h4U">
-                                        <rect key="frame" x="0.0" y="161.5" width="288" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="200.5" width="288" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zPa-sw-2Y1">
-                                        <rect key="frame" x="0.0" y="190" width="288" height="30"/>
+                                        <rect key="frame" x="0.0" y="229" width="288" height="30"/>
                                         <subviews>
                                             <slider opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="255" translatesAutoresizingMaskIntoConstraints="NO" id="7a2-qA-819">
                                                 <rect key="frame" x="-2" y="0.0" width="253.5" height="31"/>
@@ -94,7 +104,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Yy6-iV-dGc">
-                                        <rect key="frame" x="0.0" y="228" width="288" height="30"/>
+                                        <rect key="frame" x="0.0" y="267" width="288" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H1e-Cn-OPY">
                                                 <rect key="frame" x="0.0" y="0.0" width="64" height="30"/>

--- a/Week01/ColorPicker/ColorPicker/Type Extensions/UIColor.swift
+++ b/Week01/ColorPicker/ColorPicker/Type Extensions/UIColor.swift
@@ -9,7 +9,10 @@
 import UIKit
 
 extension UIColor {
-convenience init(red: Int, green: Int, blue: Int) {
-    self.init(red: CGFloat(red)/255, green: CGFloat(green)/255, blue: CGFloat(blue)/255, alpha: 1.0)
+    convenience init(red: Int, green: Int, blue: Int) {
+        self.init(red: CGFloat(red)/255, green: CGFloat(green)/255, blue: CGFloat(blue)/255, alpha: 1.0)
+    }
+    convenience init(hue: Int, saturation: Int, brightness: Int) {
+        self.init(hue: CGFloat(hue)/360, saturation: CGFloat(saturation)/100, brightness: CGFloat(brightness)/100, alpha: 1.0)
     }
 }

--- a/Week01/ColorPicker/ColorPicker/ViewController.swift
+++ b/Week01/ColorPicker/ColorPicker/ViewController.swift
@@ -14,6 +14,11 @@ enum SelectedSliderTag: Int {
     case Third
 }
 
+enum ColorModel {
+    case RGB
+    case HSB
+}
+
 class ViewController: UIViewController {
 
     var firstSliderValue = 0
@@ -21,9 +26,15 @@ class ViewController: UIViewController {
     var thirdSliderValue = 0
     
     var colorName = ""
+    var colorModel: ColorModel = .RGB
     var backgroundColor: UIColor {
         get {
-            return UIColor.init(red: firstSliderValue, green: secondSliderValue, blue: thirdSliderValue)
+            switch colorModel {
+            case .RGB:
+                return UIColor.init(red: firstSliderValue, green: secondSliderValue, blue: thirdSliderValue)
+            case .HSB:
+                return UIColor.init(hue: firstSliderValue, saturation: secondSliderValue, brightness: thirdSliderValue)
+            }
         }
     }
 
@@ -80,6 +91,36 @@ class ViewController: UIViewController {
         }
         
         updateSliderValueLabels()
+    }
+
+    @IBAction func colorModelChanged(_ segmentedControl: UISegmentedControl) {
+        switch segmentedControl.selectedSegmentIndex {
+        case 0:
+            colorModel = .RGB
+        case 1:
+            colorModel = .HSB
+        default:
+            return
+        }
+        
+        switch colorModel {
+        case .RGB:
+            firstSliderTitleLabel.text = "Red"
+            firstSlider.maximumValue = 255
+            secondSliderTitleLabel.text = "Green"
+            secondSlider.maximumValue = 255
+            thirdSliderTitleLabel.text = "Blue"
+            thirdSlider.maximumValue = 255
+        case .HSB:
+            firstSliderTitleLabel.text = "Hue"
+            firstSlider.maximumValue = 360
+            secondSliderTitleLabel.text = "Saturation"
+            secondSlider.maximumValue = 100
+            thirdSliderTitleLabel.text = "Brightness"
+            thirdSlider.maximumValue = 100
+        }
+        
+        resetValues()
     }
 
     func updateColorNameLabel() {


### PR DESCRIPTION
Changes:
- Add a UISegmentedControl below the color name label to switch between RGB and HSB
- When switching between RGB and HSB adjustments are made to the:
    - slider labels (from Red, Green, Blue to Hue, Saturation, Brightness)
    - slider max values (from 255, 255, 255, to 360, 100, 100)
    - UIColor initializer for setting the background color
    - current value (reset to default: 000)